### PR TITLE
Use the self-signed-certiciates charm by default

### DIFF
--- a/modules/controller/README.md
+++ b/modules/controller/README.md
@@ -11,7 +11,7 @@ juju model.
 includes:
 - NATS
 - Anbox Cloud Gateway
-- Certificate Authority (CA: EasyRSA)
+- Certificate Authority (CA: Self-signed-certificates)
 - Anbox Cloud Dashboard
 
 ### Some limitations of the plan

--- a/modules/controller/docs/header.md
+++ b/modules/controller/docs/header.md
@@ -10,7 +10,7 @@ juju model.
 includes:
 - NATS
 - Anbox Cloud Gateway
-- Certificate Authority (CA: EasyRSA)
+- Certificate Authority (CA: self-signed-certificates)
 - Anbox Cloud Dashboard
 
 ### Some limitations of the plan

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -102,7 +102,7 @@ resource "juju_application" "ca" {
   constraints = join(" ", var.constraints)
 
   charm {
-    name    = "easyrsa"
+    name    = "self-signed-certificates"
     base    = local.base
     channel = "latest/stable"
   }

--- a/modules/subcluster/README.md
+++ b/modules/subcluster/README.md
@@ -11,7 +11,7 @@ juju model.
 * The control plane currently includes:
 - AMS
 - ETCD (optional)
-- EasyRSA (optional)
+- Self-signed-certificates (optional)
 - Anbox Stream Agent
 - Coturn
 * The data plan includes:

--- a/modules/subcluster/control_plane.tf
+++ b/modules/subcluster/control_plane.tf
@@ -81,7 +81,7 @@ resource "juju_application" "ca" {
   constraints = join(" ", var.constraints)
 
   charm {
-    name    = "easyrsa"
+    name    = "self-signed-certificates"
     channel = "latest/stable"
     base    = local.base
   }

--- a/modules/subcluster/docs/header.md
+++ b/modules/subcluster/docs/header.md
@@ -10,7 +10,7 @@ juju model.
 * The control plane currently includes:
 - AMS
 - ETCD (optional)
-- EasyRSA (optional)
+- Self-signed-certificates (optional)
 - Anbox Stream Agent
 - Coturn
 * The data plan includes:


### PR DESCRIPTION
## Done

Replaced the use of the 'easyrsa' charm with the 'self-signed-certificates' 
charm in both controller and subcluster terraform modules.

## QA

Run integration test 

## JIRA / Launchpad bug

Fixes https://warthogs.atlassian.net/browse/AC-3317

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?

No, it doesn't