### PR TITLE
Add ssh keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ cross model relations.
 | <a name="input_deploy_registry"></a> [deploy\_registry](#input\_deploy\_registry) | Deploy the Anbox Application Registry | `bool` | `false` | no |
 | <a name="input_enable_cos"></a> [enable\_cos](#input\_enable\_cos) | Enable cos integration by deploying grafana-agent charm. | `bool` | `false` | no |
 | <a name="input_enable_ha"></a> [enable\_ha](#input\_enable\_ha) | Enable HA mode for anbox cloud | `bool` | `false` | no |
+| <a name="input_ssh_key_path"></a> [ssh\_key\_path](#input\_ssh\_key\_path) | Path to the SSH key to be imported in the juju models. No key is imported by default. | `string` | `""` | no |
 | <a name="input_subclusters"></a> [subclusters](#input\_subclusters) | List of subclusters to deploy. | <pre>list(object({<br/>    name           = string<br/>    lxd_node_count = number<br/>    registry = optional(object({<br/>      mode = optional(string)<br/>    }))<br/>  }))</pre> | `[]` | no |
 
 ## Outputs
@@ -81,6 +82,7 @@ subclusters = [
     }
   }
 ]
+ssh_key_path = "~/.ssh/id_rsa.pub"
 deploy_registry = true
 enable_ha = false
 enable_cos = false

--- a/docs/footer.md
+++ b/docs/footer.md
@@ -19,6 +19,7 @@ subclusters = [
     }
   }
 ]
+ssh_key_path = "~/.ssh/id_rsa.pub"
 deploy_registry = true
 enable_ha = false
 enable_cos = false

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ module "subcluster" {
   enable_ha       = var.enable_ha
   registry_config = each.value.registry_config
   enable_cos      = var.enable_cos
+  ssh_public_key  = length(var.ssh_key_path) > 0 ? file(var.ssh_key_path) : ""
 
   // We let the `lxd_node_count` value override the HA configuration for number
   // of LXD nodes.
@@ -26,19 +27,21 @@ module "subcluster" {
 }
 
 module "controller" {
-  source      = "./modules/controller"
-  channel     = var.anbox_channel
-  constraints = var.constraints
-  enable_ha   = var.enable_ha
-  enable_cos  = var.enable_cos
+  source         = "./modules/controller"
+  channel        = var.anbox_channel
+  constraints    = var.constraints
+  enable_ha      = var.enable_ha
+  enable_cos     = var.enable_cos
+  ssh_public_key = length(var.ssh_key_path) > 0 ? file(var.ssh_key_path) : ""
 }
 
 module "registry" {
-  count       = var.deploy_registry ? 1 : 0
-  source      = "./modules/registry"
-  channel     = var.anbox_channel
-  constraints = var.constraints
-  enable_ha   = var.enable_ha
+  count          = var.deploy_registry ? 1 : 0
+  source         = "./modules/registry"
+  channel        = var.anbox_channel
+  constraints    = var.constraints
+  enable_ha      = var.enable_ha
+  ssh_public_key = length(var.ssh_key_path) > 0 ? file(var.ssh_key_path) : ""
 }
 
 resource "juju_integration" "agent_nats_cmr" {

--- a/modules/controller/README.md
+++ b/modules/controller/README.md
@@ -11,7 +11,7 @@ juju model.
 includes:
 - NATS
 - Anbox Cloud Gateway
-- Certificate Authority (CA: Self-signed-certificates)
+- Certificate Authority (CA: self-signed-certificates)
 - Anbox Cloud Dashboard
 
 ## Requirements
@@ -49,6 +49,7 @@ No modules.
 | [juju_machine.controller_node](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/machine) | resource |
 | [juju_model.controller](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/model) | resource |
 | [juju_offer.nats_offer](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/offer) | resource |
+| [juju_ssh_key.this](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/ssh_key) | resource |
 
 ## Inputs
 
@@ -58,6 +59,7 @@ No modules.
 | <a name="input_constraints"></a> [constraints](#input\_constraints) | List of constraints that need to be applied to applications. Each constraint must be of format `<constraint_name>=<constraint_value>` | `list(string)` | `[]` | no |
 | <a name="input_enable_cos"></a> [enable\_cos](#input\_enable\_cos) | Enable cos integration by deploying grafana-agent charm. | `bool` | `false` | no |
 | <a name="input_enable_ha"></a> [enable\_ha](#input\_enable\_ha) | Number of lxd nodes to deploy per subcluster | `bool` | `false` | no |
+| <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | SSH key to be imported in the juju models. No key is imported by default. | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -18,6 +18,11 @@ resource "juju_model" "controller" {
   }
 }
 
+resource "juju_ssh_key" "this" {
+  count   = length(var.ssh_public_key) > 0 ? 1 : 0
+  model   = juju_model.controller.name
+  payload = trim(var.ssh_public_key, "\n")
+}
 
 resource "juju_application" "nats" {
   name = "nats"

--- a/modules/controller/tests/controller.tftest.hcl
+++ b/modules/controller/tests/controller.tftest.hcl
@@ -3,8 +3,9 @@
 //
 
 variables {
-  channel     = "1.26/stable"
-  constraints = [""]
+  channel        = "1.26/stable"
+  constraints    = [""]
+  ssh_public_key = "ssh-rsa test-key a@b"
 }
 
 run "test_base_controller_resources" {
@@ -12,6 +13,10 @@ run "test_base_controller_resources" {
   assert {
     condition     = length(juju_model.controller) > 0
     error_message = "Model not created in controller."
+  }
+  assert {
+    condition     = length(juju_ssh_key.this) > 0
+    error_message = "SSH Key not imported in the model."
   }
   assert {
     condition     = length(juju_machine.controller_node) == 1

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -26,3 +26,9 @@ variable "enable_cos" {
   default     = false
 }
 
+variable "ssh_public_key" {
+  description = "SSH key to be imported in the juju models. No key is imported by default."
+  type        = string
+  default     = ""
+}
+

--- a/modules/registry/README.md
+++ b/modules/registry/README.md
@@ -36,6 +36,7 @@ No modules.
 | [juju_model.registry](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/model) | resource |
 | [juju_offer.client_offer](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/offer) | resource |
 | [juju_offer.publisher_offer](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/offer) | resource |
+| [juju_ssh_key.this](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/ssh_key) | resource |
 
 ## Inputs
 
@@ -44,6 +45,7 @@ No modules.
 | <a name="input_channel"></a> [channel](#input\_channel) | Channel for the deployed charm | `string` | `"latest/stable"` | no |
 | <a name="input_constraints"></a> [constraints](#input\_constraints) | List of constraints that need to be applied to applications. Each constraint must be of format `<constraint_name>=<constraint_value>` | `list(string)` | `[]` | no |
 | <a name="input_enable_ha"></a> [enable\_ha](#input\_enable\_ha) | Number of lxd nodes to deploy per subcluster | `bool` | `false` | no |
+| <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | SSH key to be imported in the juju models. No key is imported by default. | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/registry/main.tf
+++ b/modules/registry/main.tf
@@ -18,6 +18,11 @@ resource "juju_model" "registry" {
   }
 }
 
+resource "juju_ssh_key" "this" {
+  count   = length(var.ssh_public_key) > 0 ? 1 : 0
+  model   = juju_model.registry.name
+  payload = trim(var.ssh_public_key, "\n")
+}
 
 resource "juju_application" "aar" {
   name = "aar"

--- a/modules/registry/tests/registry.tftest.hcl
+++ b/modules/registry/tests/registry.tftest.hcl
@@ -6,6 +6,7 @@ variables {
   ubuntu_pro_token = "token"
   channel          = "1.26/stable"
   constraints      = [""]
+  ssh_public_key   = "ssh-rsa key a@b"
 }
 
 run "test_base_controller_resources" {
@@ -17,6 +18,10 @@ run "test_base_controller_resources" {
   assert {
     condition     = length(juju_application.aar) > 0
     error_message = "AAR should be deployed."
+  }
+  assert {
+    condition     = length(juju_ssh_key.this) > 0
+    error_message = "SSH Key not imported in the model."
   }
 }
 

--- a/modules/registry/variables.tf
+++ b/modules/registry/variables.tf
@@ -20,3 +20,9 @@ variable "enable_ha" {
   default     = false
 }
 
+variable "ssh_public_key" {
+  description = "SSH key to be imported in the juju models. No key is imported by default."
+  type        = string
+  default     = ""
+}
+

--- a/modules/subcluster/README.md
+++ b/modules/subcluster/README.md
@@ -67,6 +67,7 @@ No modules.
 | [juju_machine.lxd_node](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/machine) | resource |
 | [juju_model.subcluster](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/model) | resource |
 | [juju_offer.ams_offer](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/offer) | resource |
+| [juju_ssh_key.this](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/ssh_key) | resource |
 
 ## Inputs
 
@@ -80,6 +81,7 @@ No modules.
 | <a name="input_lxd_nodes"></a> [lxd\_nodes](#input\_lxd\_nodes) | Channel for the deployed charm | `number` | `1` | no |
 | <a name="input_model_suffix"></a> [model\_suffix](#input\_model\_suffix) | Suffix to attach for model | `string` | n/a | yes |
 | <a name="input_registry_config"></a> [registry\_config](#input\_registry\_config) | Object to represent connection details for connecting to anbox registry | <pre>object({<br/>    mode      = string<br/>    offer_url = string<br/>  })</pre> | `null` | no |
+| <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | SSH key to be imported in the juju models. No key is imported by default. | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/subcluster/control_plane.tf
+++ b/modules/subcluster/control_plane.tf
@@ -20,6 +20,12 @@ resource "juju_model" "subcluster" {
   }
 }
 
+resource "juju_ssh_key" "this" {
+  count   = length(var.ssh_public_key) > 0 ? 1 : 0
+  model   = juju_model.subcluster.name
+  payload = trim(var.ssh_public_key, "\n")
+}
+
 resource "juju_application" "ams" {
   name = "ams"
 

--- a/modules/subcluster/tests/base_deploy.tftest.hcl
+++ b/modules/subcluster/tests/base_deploy.tftest.hcl
@@ -66,11 +66,16 @@ run "test_external_etcd_disabled" {
 run "test_base_deployment_layout" {
   command = plan
   variables {
-    model_suffix = "-a"
+    model_suffix   = "-a"
+    ssh_public_key = "ssh-rsa test-key a@b"
   }
   assert {
     condition     = length(juju_machine.ams_node) == 1
     error_message = "A separate machine should be created for AMS."
+  }
+  assert {
+    condition     = length(juju_ssh_key.this) > 0
+    error_message = "SSH Key not imported in the model."
   }
   assert {
     condition     = length(juju_machine.lxd_node) == 1

--- a/modules/subcluster/variables.tf
+++ b/modules/subcluster/variables.tf
@@ -52,3 +52,9 @@ variable "enable_cos" {
   default     = false
 }
 
+variable "ssh_public_key" {
+  description = "SSH key to be imported in the juju models. No key is imported by default."
+  type        = string
+  default     = ""
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -55,3 +55,10 @@ variable "deploy_registry" {
   type        = bool
   default     = false
 }
+
+variable "ssh_key_path" {
+  description = "Path to the SSH key to be imported in the juju models. No key is imported by default."
+  type        = string
+  default     = ""
+}
+


### PR DESCRIPTION
## Done

* Add the capability to provide ssh key to be imported in the model. By default no keys are imported in the created models.

## QA

* Passes CI.

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
Yes, readme updated.
