### PR TITLE
feat(modules): use 2/stable track for nats charm in the plan

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -60,7 +60,7 @@ jobs:
           done
       - name: Deploy Main Plan
         env:
-          ANBOX_CHANNEL: 1.26/edge
+          ANBOX_CHANNEL: 1.27/stable
         run: |
           cat <<EOF > ci.tfvars
           anbox_channel  = "${ANBOX_CHANNEL}"

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Create terraform Plan
       run: |
         cat <<EOF > default.auto.tfvars
-        anbox_channel  = "1.26/stable"
+        anbox_channel  = "1.27/stable"
         subclusters = [
           {
             name           = "a"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ variable `var.subclusters_per_region`. To execute the terraform plan:
 
 ```tfvars
 ubuntu_pro_token = "<pro_token_here>"
-anbox_channel    = "1.26/edge"
+anbox_channel    = "1.27/stable"
 subclusters = [
   {
     name           = "a"

--- a/docs/footer.md
+++ b/docs/footer.md
@@ -9,7 +9,7 @@ variable `var.subclusters_per_region`. To execute the terraform plan:
 
 ```tfvars
 ubuntu_pro_token = "<pro_token_here>"
-anbox_channel    = "1.26/edge"
+anbox_channel    = "1.27/stable"
 subclusters = [
   {
     name           = "a"

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -32,7 +32,7 @@ resource "juju_application" "nats" {
 
   charm {
     name    = "nats"
-    channel = "latest/edge"
+    channel = "2/stable"
     base    = local.base
   }
 

--- a/modules/controller/tests/controller.tftest.hcl
+++ b/modules/controller/tests/controller.tftest.hcl
@@ -3,7 +3,7 @@
 //
 
 variables {
-  channel        = "1.26/stable"
+  channel        = "1.27/stable"
   constraints    = [""]
   ssh_public_key = "ssh-rsa test-key a@b"
 }

--- a/modules/registry/tests/registry.tftest.hcl
+++ b/modules/registry/tests/registry.tftest.hcl
@@ -4,7 +4,7 @@
 
 variables {
   ubuntu_pro_token = "token"
-  channel          = "1.26/stable"
+  channel          = "1.27/stable"
   constraints      = [""]
   ssh_public_key   = "ssh-rsa key a@b"
 }

--- a/tests/base_deployment.tftest.hcl
+++ b/tests/base_deployment.tftest.hcl
@@ -14,7 +14,7 @@ run "test_required_variables" {
 run "test_models_per_subcluster" {
   command = plan
   variables {
-    anbox_channel = "1.26/edge"
+    anbox_channel = "1.27/stable"
     subclusters = [{
       name           = "a"
       lxd_node_count = 1

--- a/tests/registry.tftest.hcl
+++ b/tests/registry.tftest.hcl
@@ -5,7 +5,7 @@
 run "test_registry" {
   command = plan
   variables {
-    anbox_channel = "1.26/edge"
+    anbox_channel = "1.27/stable"
     subclusters = [{
       name           = "a"
       lxd_node_count = 1


### PR DESCRIPTION
## Done

The main plan for the controller module bundle now aligns with the
latest nats charm release on channel 2/stable rather than latest/edge, 
which lacks features, e.g.  self-signed-certificate TLS charm support 
and secret support.

## QA

PR workflow would work without a problem

## JIRA / Launchpad bug

Fixes https://warthogs.atlassian.net/browse/AC-3677

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
A: no, it doesn't.