### PR TITLE
Remove ams-node-controller charm from the data plane plan

### DIFF
--- a/modules/subcluster/README.md
+++ b/modules/subcluster/README.md
@@ -16,7 +16,6 @@ juju model.
 - Coturn
 * The data plan includes:
 - LXD
-- AMS-Node-Controller
 * This module can deploy a number of LXD machines to act as nodes to AMS using the
 input variable `var.lxd_nodes`.
 * Each LXD node is accompanied by a subordinate charm `ams-node-controller` to
@@ -45,7 +44,6 @@ No modules.
 |------|------|
 | [juju_application.agent](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_application.ams](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
-| [juju_application.ams_node_controller](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_application.ca](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_application.cos_agent](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_application.coturn](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
@@ -61,7 +59,6 @@ No modules.
 | [juju_integration.ams_lxd](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
 | [juju_integration.coturn_agent](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
 | [juju_integration.etcd_ca](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
-| [juju_integration.ip_table_rules](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
 | [juju_machine.ams_node](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/machine) | resource |
 | [juju_machine.db_node](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/machine) | resource |
 | [juju_machine.lxd_node](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/machine) | resource |

--- a/modules/subcluster/data_plane.tf
+++ b/modules/subcluster/data_plane.tf
@@ -23,37 +23,6 @@ resource "juju_application" "lxd" {
   }
 }
 
-resource "juju_application" "ams_node_controller" {
-  name = "ams-node-controller"
-
-  model = juju_model.subcluster.name
-
-  charm {
-    name    = "ams-node-controller"
-    channel = var.channel
-    base    = local.base
-  }
-
-  config = {
-    port            = "10000-11000"
-    snap_risk_level = local.risk
-  }
-}
-
-resource "juju_integration" "ip_table_rules" {
-  model = juju_model.subcluster.name
-
-  application {
-    name     = juju_application.ams_node_controller.name
-    endpoint = "lxd"
-  }
-
-  application {
-    name     = juju_application.lxd.name
-    endpoint = "api"
-  }
-}
-
 resource "juju_integration" "ams_lxd" {
   model = juju_model.subcluster.name
 

--- a/modules/subcluster/docs/header.md
+++ b/modules/subcluster/docs/header.md
@@ -15,7 +15,6 @@ juju model.
 - Coturn
 * The data plan includes:
 - LXD
-- AMS-Node-Controller
 * This module can deploy a number of LXD machines to act as nodes to AMS using the
 input variable `var.lxd_nodes`.
 * Each LXD node is accompanied by a subordinate charm `ams-node-controller` to

--- a/modules/subcluster/tests/base_deploy.tftest.hcl
+++ b/modules/subcluster/tests/base_deploy.tftest.hcl
@@ -126,16 +126,8 @@ run "test_base_deployment_layout" {
     error_message = "AMS should be related to LXD."
   }
   assert {
-    condition     = length(juju_integration.ip_table_rules) > 0
-    error_message = "LXD should be related to AMS Node Controller."
-  }
-  assert {
     condition     = juju_application.lxd.units == 1
     error_message = "Default number of lxd nodes should be 1."
-  }
-  assert {
-    condition     = length(juju_application.ams_node_controller) > 0
-    error_message = "AMS Node Controller should be deployed by default."
   }
   assert {
     condition     = length(juju_integration.ams_aar) == 0

--- a/modules/subcluster/tests/ha_deployment.tftest.hcl
+++ b/modules/subcluster/tests/ha_deployment.tftest.hcl
@@ -64,12 +64,4 @@ run "test_ha_deployment" {
     condition     = length(juju_integration.ams_lxd) > 0
     error_message = "AMS should be related to LXD"
   }
-  assert {
-    condition     = length(juju_integration.ip_table_rules) > 0
-    error_message = "LXD should be related to AMS Node Controller"
-  }
-  assert {
-    condition     = length(juju_application.ams_node_controller) > 0
-    error_message = "AMS Node Controller should be deployed by default."
-  }
 }


### PR DESCRIPTION
## Done

The ams-node-controller ended up to the blocked at times when running
terraform plan test. Also due to the fact that
1. ams-node-controller is no longer charge of the port forwarding
    for ams instance since 1.27 release
2. ams-node-controller is deprecated and will be completely dropped
    in 1.28.0 release.
    
Hence removing its reference from the plan.

## QA

Ensure static and terraform tests pass 

## JIRA / Launchpad bug

Fixes https://github.com/canonical/anbox-cloud-terraform/actions/runs/17993936793/job/51189498101

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
A: yes, in 1.28 release announcement.