### PR TITLE
Forward ubuntu_pro_token to all relevant charms

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/juju/juju" {
   constraints = "~> 0.19.0"
   hashes = [
     "h1:QzSjUIELE2QEsZCYrOSMrCopgasqwJpmzjgsc++igrM=",
+    "h1:sWo4pFb0CYEqLFX2OF/ObAB8vZFZUgL/lceamTLyHsc=",
     "zh:1d5c0b2671052bbc4600dae6b07bd5d0ca0ca492e2b8c408e3358518cca419dd",
     "zh:26b8f4e409d22ab21ed4a9d192a8d40f3887bf0ac1865b427102327ccec30502",
     "zh:3e52068e40067ab8f68ee12a56e733fe73180050c0e9644da87ded6a1eab0d1a",

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ cross model relations.
 | <a name="input_enable_ha"></a> [enable\_ha](#input\_enable\_ha) | Enable HA mode for anbox cloud | `bool` | `false` | no |
 | <a name="input_ssh_key_path"></a> [ssh\_key\_path](#input\_ssh\_key\_path) | Path to the SSH key to be imported in the juju models. No key is imported by default. | `string` | `""` | no |
 | <a name="input_subclusters"></a> [subclusters](#input\_subclusters) | List of subclusters to deploy. | <pre>list(object({<br/>    name           = string<br/>    lxd_node_count = number<br/>    registry = optional(object({<br/>      mode = optional(string)<br/>    }))<br/>  }))</pre> | `[]` | no |
+| <a name="input_ubuntu_pro_token"></a> [ubuntu_pro_token](#input_ubuntu_pro_token) | Ubuntu Advantage token that is received with your license of Anbox Cloud. This will be forwarded to all relevant charms as `ua_token`. | `string` | `""` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -10,16 +10,17 @@ locals {
 }
 
 module "subcluster" {
-  for_each        = local.subcluster_config_map
-  source          = "./modules/subcluster"
-  model_suffix    = each.key
-  channel         = var.anbox_channel
-  external_etcd   = true
-  constraints     = var.constraints
-  enable_ha       = var.enable_ha
-  registry_config = each.value.registry_config
-  enable_cos      = var.enable_cos
-  ssh_public_key  = length(var.ssh_key_path) > 0 ? file(var.ssh_key_path) : ""
+  for_each         = local.subcluster_config_map
+  source           = "./modules/subcluster"
+  model_suffix     = each.key
+  channel          = var.anbox_channel
+  external_etcd    = true
+  constraints      = var.constraints
+  enable_ha        = var.enable_ha
+  registry_config  = each.value.registry_config
+  enable_cos       = var.enable_cos
+  ssh_public_key   = length(var.ssh_key_path) > 0 ? file(var.ssh_key_path) : ""
+  ubuntu_pro_token = var.ubuntu_pro_token
 
   // We let the `lxd_node_count` value override the HA configuration for number
   // of LXD nodes.
@@ -27,21 +28,23 @@ module "subcluster" {
 }
 
 module "controller" {
-  source         = "./modules/controller"
-  channel        = var.anbox_channel
-  constraints    = var.constraints
-  enable_ha      = var.enable_ha
-  enable_cos     = var.enable_cos
-  ssh_public_key = length(var.ssh_key_path) > 0 ? file(var.ssh_key_path) : ""
+  source           = "./modules/controller"
+  channel          = var.anbox_channel
+  constraints      = var.constraints
+  enable_ha        = var.enable_ha
+  enable_cos       = var.enable_cos
+  ssh_public_key   = length(var.ssh_key_path) > 0 ? file(var.ssh_key_path) : ""
+  ubuntu_pro_token = var.ubuntu_pro_token
 }
 
 module "registry" {
-  count          = var.deploy_registry ? 1 : 0
-  source         = "./modules/registry"
-  channel        = var.anbox_channel
-  constraints    = var.constraints
-  enable_ha      = var.enable_ha
-  ssh_public_key = length(var.ssh_key_path) > 0 ? file(var.ssh_key_path) : ""
+  count            = var.deploy_registry ? 1 : 0
+  source           = "./modules/registry"
+  channel          = var.anbox_channel
+  constraints      = var.constraints
+  enable_ha        = var.enable_ha
+  ssh_public_key   = length(var.ssh_key_path) > 0 ? file(var.ssh_key_path) : ""
+  ubuntu_pro_token = var.ubuntu_pro_token
 }
 
 resource "juju_integration" "agent_nats_cmr" {

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -62,6 +62,7 @@ resource "juju_application" "gateway" {
 
   config = {
     snap_risk_level = local.risk
+    ua_token        = var.ubuntu_pro_token
   }
 
   // FIXME: Currently the provider has some issues with reconciling state using
@@ -86,6 +87,7 @@ resource "juju_application" "dashboard" {
 
   config = {
     snap_risk_level = local.risk
+    ua_token        = var.ubuntu_pro_token
   }
 
   machines = juju_machine.controller_node[*].machine_id

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -32,3 +32,8 @@ variable "ssh_public_key" {
   default     = ""
 }
 
+variable "ubuntu_pro_token" {
+  description = "Ubuntu Advantage token that is received with your license of Anbox Cloud."
+  type        = string
+  default     = ""
+}

--- a/modules/registry/main.tf
+++ b/modules/registry/main.tf
@@ -40,6 +40,7 @@ resource "juju_application" "aar" {
 
   config = {
     snap_risk_level = local.risk
+    ua_token        = var.ubuntu_pro_token
   }
 
   // FIXME: Currently the provider has some issues with reconciling state using

--- a/modules/registry/variables.tf
+++ b/modules/registry/variables.tf
@@ -26,3 +26,8 @@ variable "ssh_public_key" {
   default     = ""
 }
 
+variable "ubuntu_pro_token" {
+  description = "Ubuntu Advantage token that is received with your license of Anbox Cloud."
+  type        = string
+  default     = ""
+}

--- a/modules/subcluster/control_plane.tf
+++ b/modules/subcluster/control_plane.tf
@@ -38,10 +38,10 @@ resource "juju_application" "ams" {
     channel = var.channel
     base    = local.base
   }
-
   config = {
     use_embedded_etcd = !var.external_etcd
     snap_risk_level   = local.risk
+    ua_token          = var.ubuntu_pro_token
   }
 
   // FIXME: Currently the provider has some issues with reconciling state using
@@ -156,6 +156,7 @@ resource "juju_application" "agent" {
   config = {
     region          = "cloud-0"
     snap_risk_level = local.risk
+    ua_token        = var.ubuntu_pro_token
   }
 
   // FIXME: Currently the provider has some issues with reconciling state using

--- a/modules/subcluster/variables.tf
+++ b/modules/subcluster/variables.tf
@@ -58,3 +58,9 @@ variable "ssh_public_key" {
   default     = ""
 }
 
+variable "ubuntu_pro_token" {
+  description = "Ubuntu Advantage token that is received with your license of Anbox Cloud."
+  type        = string
+  default     = ""
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,12 @@ variable "subclusters" {
   }
 }
 
+variable "ubuntu_pro_token" {
+  description = "Ubuntu Advantage token that is received with your license of Anbox Cloud."
+  type        = string
+  default     = ""
+}
+
 variable "enable_cos" {
   description = "Enable cos integration by deploying grafana-agent charm."
   type        = bool


### PR DESCRIPTION
## Done

Forward ubuntu_pro_token to all relevant charms as ua_token via
terraform modules. Add variable declarations and propagate the value
to controller, registry, and subcluster modules for proper charm
configuration.

## QA

1. Add a terraform plan file named `deploy.tfvars` with the following content
```
ubuntu_pro_token = "xxx"
anbox_channel  = "1.27/stable"
subclusters = [
  {
    name           = "a"
    lxd_node_count = 1
    registry = {
      mode   = "client"
    }
  }
]
deploy_registry=true
constraints=["arch=amd64"]
```
2. Deploy the anbox cloud with terraform plan
  terraform init && terraform apply -parallelism=1 -auto-approve -var-file='deploy.tfvars'
3. Check the following models:
    - anbox-subcluster-a
    - anbox-registry
    - anbox-controller
all charms in the above models are active with no status message like `Ubuntu Pro token is not attached` displayed    

## JIRA / Launchpad bug

Fixes https://bugs.launchpad.net/anbox-cloud/+bug/2135083

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
A: no, the tf varilable `ubuntu_pro_token`  has been documented and used in our [documentation](https://documentation.ubuntu.com/anbox-cloud/howto/install/deploy-terraform/).  