### PR TITLE
Add missing ua_token config to ams-lxd charm

### DIFF
--- a/modules/subcluster/data_plane.tf
+++ b/modules/subcluster/data_plane.tf
@@ -14,6 +14,10 @@ resource "juju_application" "lxd" {
     base    = local.base
   }
 
+  config = {
+    ua_token = var.ubuntu_pro_token
+  }
+
   machines = juju_machine.lxd_node[*].machine_id
   // FIXME: Currently the provider has some issues with reconciling state using
   // the response from the JUJU APIs. This is done just to ignore the changes in


### PR DESCRIPTION
Fixes an issue where the status message of ams-lxd charm get stuck to 
reflect the Ubuntu Pro attachment status due to a missing ua_token config field.

This is a missing piece since the last umbrella change.
```
    commit f5ec6dd5253adceb852c69dab7d70b1c965c1717 (main)
    Date:   Mon Dec 15 10:02:32 2025 +0800
    Author: gary-wzl77 <gary.wang@canonical.com>
    
        fix(modules): forward ubuntu_pro_token to all relevant charms
```

## Done

[Summary of work items]

## QA

[Steps for testing the changes]

## JIRA / Launchpad bug

Fixes https://bugs.launchpad.net/anbox-cloud/+bug/2135083

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
