### PR TITLE
Drop legacy charms

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -103,3 +103,19 @@ jobs:
 
           echo "All models deployed successfully"
 
+      - name: Upload test logs
+        if: failure()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: logs-tests-anbox-cloud-terraform
+          path: logs/
+          retention-days: 4
+      # FIXME: The current post actions-operator tries to upload any artifact called
+      # juju-crashdump-* with name juju-crashdump which github is not happy with.
+      # so we remove the files before the cleanup so that the cleanup does not
+      # fail.
+      - name: Remove logs if present
+        if: failure()
+        run: |
+          rm -rf logs/juju-crashdump-*
+

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -60,7 +60,7 @@ jobs:
           done
       - name: Deploy Main Plan
         env:
-          ANBOX_CHANNEL: 1.27/stable
+          ANBOX_CHANNEL: 1.29/edge
         run: |
           cat <<EOF > ci.tfvars
           anbox_channel  = "${ANBOX_CHANNEL}"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ variable `var.subclusters_per_region`. To execute the terraform plan:
 
 ```tfvars
 ubuntu_pro_token = "<pro_token_here>"
-anbox_channel    = "1.27/stable"
+anbox_channel    = "1.29/edge"
 subclusters = [
   {
     name           = "a"

--- a/docs/footer.md
+++ b/docs/footer.md
@@ -9,7 +9,7 @@ variable `var.subclusters_per_region`. To execute the terraform plan:
 
 ```tfvars
 ubuntu_pro_token = "<pro_token_here>"
-anbox_channel    = "1.27/stable"
+anbox_channel    = "1.29/edge"
 subclusters = [
   {
     name           = "a"

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -109,7 +109,7 @@ resource "juju_application" "ca" {
   charm {
     name    = "self-signed-certificates"
     base    = local.base
-    channel = "latest/stable"
+    channel = "1/stable"
   }
 
   machines = juju_machine.controller_node[*].machine_id

--- a/modules/controller/provider.tf
+++ b/modules/controller/provider.tf
@@ -13,7 +13,7 @@ terraform {
 }
 
 locals {
-  base           = "ubuntu@22.04"
+  base           = "ubuntu@24.04"
   _channel_split = split("/", var.channel)
   risk           = element(local._channel_split, length(local._channel_split) - 1)
 }

--- a/modules/controller/tests/controller.tftest.hcl
+++ b/modules/controller/tests/controller.tftest.hcl
@@ -3,7 +3,7 @@
 //
 
 variables {
-  channel        = "1.27/stable"
+  channel        = "1.29/edge"
   constraints    = [""]
   ssh_public_key = "ssh-rsa test-key a@b"
 }

--- a/modules/registry/provider.tf
+++ b/modules/registry/provider.tf
@@ -13,7 +13,7 @@ terraform {
 }
 
 locals {
-  base           = "ubuntu@22.04"
+  base           = "ubuntu@24.04"
   _channel_split = split("/", var.channel)
   risk           = element(local._channel_split, length(local._channel_split) - 1)
 }

--- a/modules/registry/tests/registry.tftest.hcl
+++ b/modules/registry/tests/registry.tftest.hcl
@@ -4,7 +4,7 @@
 
 variables {
   ubuntu_pro_token = "token"
-  channel          = "1.27/stable"
+  channel          = "1.29/edge"
   constraints      = [""]
   ssh_public_key   = "ssh-rsa key a@b"
 }

--- a/modules/subcluster/control_plane.tf
+++ b/modules/subcluster/control_plane.tf
@@ -60,13 +60,9 @@ resource "juju_application" "etcd" {
   constraints = join(" ", var.constraints)
 
   charm {
-    name    = "etcd"
-    channel = "latest/stable"
+    name    = "charmed-etcd"
+    channel = "3.6/stable"
     base    = local.base
-  }
-
-  config = {
-    channel = "3.4/stable"
   }
 
   machines = juju_machine.db_node[*].machine_id
@@ -86,7 +82,7 @@ resource "juju_application" "ca" {
 
   charm {
     name    = "self-signed-certificates"
-    channel = "latest/stable"
+    channel = "1/stable"
     base    = local.base
   }
 
@@ -101,8 +97,8 @@ resource "juju_application" "etcd_ca" {
   constraints = join(" ", var.constraints)
 
   charm {
-    name    = "easyrsa"
-    channel = "latest/stable"
+    name    = "self-signed-certificates"
+    channel = "1/stable"
     base    = local.base
   }
 
@@ -115,12 +111,12 @@ resource "juju_integration" "ams_db" {
 
   application {
     name     = juju_application.ams.name
-    endpoint = "etcd"
+    endpoint = "etcd-client"
   }
 
   application {
     name     = one(juju_application.etcd[*].name)
-    endpoint = "db"
+    endpoint = "etcd-client"
   }
 }
 
@@ -130,12 +126,12 @@ resource "juju_integration" "etcd_ca" {
 
   application {
     name     = one(juju_application.etcd_ca[*].name)
-    endpoint = "client"
+    endpoint = "certificates"
   }
 
   application {
     name     = one(juju_application.etcd[*].name)
-    endpoint = "certificates"
+    endpoint = "client-certificates"
   }
 }
 
@@ -219,6 +215,19 @@ resource "juju_integration" "ams_agent_streaming" {
   }
 }
 
+resource "juju_integration" "ams_ca" {
+  model = juju_model.subcluster.name
+
+  application {
+    name     = juju_application.ca.name
+    endpoint = "certificates"
+  }
+
+  application {
+    name     = juju_application.ams.name
+    endpoint = "certificates"
+  }
+}
 
 resource "juju_integration" "agent_ca" {
   model = juju_model.subcluster.name

--- a/modules/subcluster/data_plane.tf
+++ b/modules/subcluster/data_plane.tf
@@ -15,7 +15,8 @@ resource "juju_application" "lxd" {
   }
 
   config = {
-    ua_token = var.ubuntu_pro_token
+    ua_token                        = var.ubuntu_pro_token
+    node_controller_snap_risk_level = local.risk
   }
 
   machines = juju_machine.lxd_node[*].machine_id

--- a/modules/subcluster/provider.tf
+++ b/modules/subcluster/provider.tf
@@ -13,7 +13,7 @@ terraform {
 }
 
 locals {
-  base           = "ubuntu@22.04"
+  base           = "ubuntu@24.04"
   _channel_split = split("/", var.channel)
   risk           = element(local._channel_split, length(local._channel_split) - 1)
 }

--- a/modules/subcluster/tests/external_etcd.tftest.hcl
+++ b/modules/subcluster/tests/external_etcd.tftest.hcl
@@ -30,8 +30,8 @@ run "test_external_etcd_enabled" {
     error_message = "ETCD not related to CA."
   }
   assert {
-    condition     = juju_application.etcd[0].charm[0].name == "etcd"
-    error_message = "`etcd` charm should be used to deploy ETCD."
+    condition     = juju_application.etcd[0].charm[0].name == "charmed-etcd"
+    error_message = "`charmed-etcd` charm should be used to deploy ETCD."
   }
   assert {
     condition     = juju_application.etcd[0].config == tomap({ channel = "3.4/stable" })

--- a/modules/subcluster/tests/external_etcd.tftest.hcl
+++ b/modules/subcluster/tests/external_etcd.tftest.hcl
@@ -33,8 +33,4 @@ run "test_external_etcd_enabled" {
     condition     = juju_application.etcd[0].charm[0].name == "charmed-etcd"
     error_message = "`charmed-etcd` charm should be used to deploy ETCD."
   }
-  assert {
-    condition     = juju_application.etcd[0].config == tomap({ channel = "3.4/stable" })
-    error_message = "`etcd` charm should be deployed from `3.4/stable` channel by default."
-  }
 }

--- a/tests/base_deployment.tftest.hcl
+++ b/tests/base_deployment.tftest.hcl
@@ -14,7 +14,7 @@ run "test_required_variables" {
 run "test_models_per_subcluster" {
   command = plan
   variables {
-    anbox_channel = "1.27/stable"
+    anbox_channel = "1.29/edge"
     subclusters = [{
       name           = "a"
       lxd_node_count = 1

--- a/tests/registry.tftest.hcl
+++ b/tests/registry.tftest.hcl
@@ -5,7 +5,7 @@
 run "test_registry" {
   command = plan
   variables {
-    anbox_channel = "1.27/stable"
+    anbox_channel = "1.29/edge"
     subclusters = [{
       name           = "a"
       lxd_node_count = 1


### PR DESCRIPTION
## Done

Switch to modernized charms from the legacy ones for the anbox cloud
deployment. As planned, all legacy charms used by Anbox Cloud are deprecated
starting from the 1.29 release, support will be discontinued starting
with Ubuntu 28.04 (roughly Anbox Cloud 1.35.0).

To support to wire charmed-etcd charm up with ams, we need to install
ams charm from 1.29/edge channel, to facilitate the deployment with
terraform plan, anbox cloud charms are all installed from 1.29/edge
channel.
    
Once anbox cloud 1.29 is officially out, we switch to 1.29/stable
then.

## QA

[Steps for testing the changes]

## JIRA / Launchpad bug

Fixes https://warthogs.atlassian.net/browse/AC-3949

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
A: no, it doesn't. The [deploy with Terraform](https://documentation.ubuntu.com/anbox-cloud/howto/install/deploy-terraform/) page would remain unchanged.  