### PR TITLE
chore: bump terraform juju provider version to 1.3.0

### DIFF
--- a/.github/actions/setup-trivy/action.yaml
+++ b/.github/actions/setup-trivy/action.yaml
@@ -36,9 +36,9 @@ runs:
   - name: Fetch debian package for Trivy
     if: ${{ steps.cache_deb.outputs.cache-hit != 'true' }}
     env:
-      TRIVY_VERSION: "0.57.0"
+      TRIVY_VERSION: "0.69.2"
       TRIVY_ARCH: ${{ inputs.arch == 'amd64' && '64bit' || 'ARM64' }}
-      TRIVY_SHA256: ${{ inputs.arch == 'amd64' && '0ef038ae7078449b89af6dcdd1cdecd744f65b8b50432797cda78846448c62dd' || '8ae7a057a32d98818c8504c2484017598437e117b9c96858d5749942c99cf1dd' }}
+      TRIVY_SHA256: ${{ inputs.arch == 'amd64' && '7052fdc858e5381e28abe42330115da1703015a3ab172d8312b099defe85107e' || '2522ff3915d7055229d50ad91cdb77c7577cd13d94bb0e4e2688f3d8471ff81b' }}
     shell: bash
     run: |
       curl -L -o trivy.deb \

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -60,7 +60,7 @@ jobs:
           done
       - name: Deploy Main Plan
         env:
-          ANBOX_CHANNEL: 1.27/stable
+          ANBOX_CHANNEL: 1.29/stable
         run: |
           cat <<EOF > ci.tfvars
           anbox_channel  = "${ANBOX_CHANNEL}"

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,16 +2,15 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/juju/juju" {
-  version     = "0.19.0"
-  constraints = "~> 0.19.0"
+  version     = "1.3.0"
+  constraints = "~> 1.3.0"
   hashes = [
-    "h1:QzSjUIELE2QEsZCYrOSMrCopgasqwJpmzjgsc++igrM=",
-    "h1:sWo4pFb0CYEqLFX2OF/ObAB8vZFZUgL/lceamTLyHsc=",
-    "zh:1d5c0b2671052bbc4600dae6b07bd5d0ca0ca492e2b8c408e3358518cca419dd",
-    "zh:26b8f4e409d22ab21ed4a9d192a8d40f3887bf0ac1865b427102327ccec30502",
-    "zh:3e52068e40067ab8f68ee12a56e733fe73180050c0e9644da87ded6a1eab0d1a",
-    "zh:577ac4ca9e6bb6d79c209d85c3ea5f4271349443200acdd6852ff8748a13e99a",
+    "h1:+fllZKpGWcZwZ9Y6fOM9pgP+dBuB8p4u6UHR8WhMpbM=",
+    "zh:00d8e67319d6e41ed40263d18fa5b7f340f5ce59de64d94708fdb1e333557a0c",
+    "zh:52c76034d0a7e9c4441c71772c53e0b0348812ae1161ef671da6ba34445a645d",
     "zh:753ad16d007180a77a147bd377de2fb334f409123f6fee36d4c50c7fe8b76a29",
-    "zh:d62a0e40e9010712c993c39ade6d051d33d6f3e584bfefc2f7041abefcadbcef",
+    "zh:81959b968ed9002efa34036002fe5116718160b1d44ea199aac743014e849fcf",
+    "zh:ce0a0754df43dbb131a17380b28e1cb9170c6078fad2c353370b034f03c755b1",
+    "zh:f6675e89aa584444916e08603f7ae2b840690a234fadc29fae1dc841d871f5d9",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ cross model relations.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.6 |
-| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 0.19.0 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_juju"></a> [juju](#provider\_juju) | 0.19.0 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | 1.3.0 |
 
 ## Modules
 
@@ -54,7 +54,7 @@ cross model relations.
 | <a name="input_enable_ha"></a> [enable\_ha](#input\_enable\_ha) | Enable HA mode for anbox cloud | `bool` | `false` | no |
 | <a name="input_ssh_key_path"></a> [ssh\_key\_path](#input\_ssh\_key\_path) | Path to the SSH key to be imported in the juju models. No key is imported by default. | `string` | `""` | no |
 | <a name="input_subclusters"></a> [subclusters](#input\_subclusters) | List of subclusters to deploy. | <pre>list(object({<br/>    name           = string<br/>    lxd_node_count = number<br/>    registry = optional(object({<br/>      mode = optional(string)<br/>    }))<br/>  }))</pre> | `[]` | no |
-| <a name="input_ubuntu_pro_token"></a> [ubuntu_pro_token](#input_ubuntu_pro_token) | Ubuntu Advantage token that is received with your license of Anbox Cloud. This will be forwarded to all relevant charms as `ua_token`. | `string` | `""` | no |
+| <a name="input_ubuntu_pro_token"></a> [ubuntu\_pro\_token](#input\_ubuntu\_pro\_token) | Ubuntu Advantage token that is received with your license of Anbox Cloud. | `string` | `""` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -48,8 +48,8 @@ module "registry" {
 }
 
 resource "juju_integration" "agent_nats_cmr" {
-  for_each = module.subcluster
-  model    = each.value.model_name
+  for_each   = module.subcluster
+  model_uuid = each.value.model_uuid
 
   application {
     name     = each.value.agent_app_name
@@ -62,8 +62,8 @@ resource "juju_integration" "agent_nats_cmr" {
 }
 
 resource "juju_integration" "dashboard_ams_cmr" {
-  for_each = module.subcluster
-  model    = module.controller.model_name
+  for_each   = module.subcluster
+  model_uuid = module.controller.model_uuid
 
   application {
     name     = module.controller.dashboard_app_name

--- a/modules/controller/README.md
+++ b/modules/controller/README.md
@@ -19,7 +19,7 @@ includes:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.6 |
-| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 0.19.0 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.3.0 |
 
 ## Providers
 
@@ -60,6 +60,7 @@ No modules.
 | <a name="input_enable_cos"></a> [enable\_cos](#input\_enable\_cos) | Enable cos integration by deploying grafana-agent charm. | `bool` | `false` | no |
 | <a name="input_enable_ha"></a> [enable\_ha](#input\_enable\_ha) | Number of lxd nodes to deploy per subcluster | `bool` | `false` | no |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | SSH key to be imported in the juju models. No key is imported by default. | `string` | `""` | no |
+| <a name="input_ubuntu_pro_token"></a> [ubuntu\_pro\_token](#input\_ubuntu\_pro\_token) | Ubuntu Advantage token that is received with your license of Anbox Cloud. | `string` | `""` | no |
 
 ## Outputs
 
@@ -67,5 +68,6 @@ No modules.
 |------|-------------|
 | <a name="output_dashboard_app_name"></a> [dashboard\_app\_name](#output\_dashboard\_app\_name) | Anbox Cloud Dashboard application name deployed in the controller model. |
 | <a name="output_model_name"></a> [model\_name](#output\_model\_name) | Model name for the deployed controller. |
+| <a name="output_model_uuid"></a> [model\_uuid](#output\_model\_uuid) | Model uuid for the deployed controller. |
 | <a name="output_nats_offer_url"></a> [nats\_offer\_url](#output\_nats\_offer\_url) | Juju offer url for connecting to the NATS charm. |
 <!-- END_TF_DOCS -->

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -19,15 +19,15 @@ resource "juju_model" "controller" {
 }
 
 resource "juju_ssh_key" "this" {
-  count   = length(var.ssh_public_key) > 0 ? 1 : 0
-  model   = juju_model.controller.name
-  payload = trim(var.ssh_public_key, "\n")
+  count      = length(var.ssh_public_key) > 0 ? 1 : 0
+  model_uuid = juju_model.controller.uuid
+  payload    = trim(var.ssh_public_key, "\n")
 }
 
 resource "juju_application" "nats" {
   name = "nats"
 
-  model       = juju_model.controller.name
+  model_uuid  = juju_model.controller.uuid
   constraints = join(" ", var.constraints)
 
   charm {
@@ -49,7 +49,7 @@ resource "juju_application" "nats" {
 resource "juju_application" "gateway" {
   name = "anbox-stream-gateway"
 
-  model       = juju_model.controller.name
+  model_uuid  = juju_model.controller.uuid
   constraints = join(" ", var.constraints)
 
   charm {
@@ -76,7 +76,7 @@ resource "juju_application" "gateway" {
 resource "juju_application" "dashboard" {
   name = "anbox-cloud-dashboard"
 
-  model       = juju_model.controller.name
+  model_uuid  = juju_model.controller.uuid
   constraints = join(" ", var.constraints)
 
   charm {
@@ -103,7 +103,7 @@ resource "juju_application" "dashboard" {
 resource "juju_application" "ca" {
   name = "ca"
 
-  model       = juju_model.controller.name
+  model_uuid  = juju_model.controller.uuid
   constraints = join(" ", var.constraints)
 
   charm {
@@ -123,7 +123,7 @@ resource "juju_application" "ca" {
 }
 
 resource "juju_integration" "gateway_nats" {
-  model = juju_model.controller.name
+  model_uuid = juju_model.controller.uuid
 
   application {
     name     = juju_application.gateway.name
@@ -137,7 +137,7 @@ resource "juju_integration" "gateway_nats" {
 }
 
 resource "juju_integration" "dashboard_gateway" {
-  model = juju_model.controller.name
+  model_uuid = juju_model.controller.uuid
 
   application {
     name     = juju_application.gateway.name
@@ -152,7 +152,7 @@ resource "juju_integration" "dashboard_gateway" {
 
 
 resource "juju_integration" "nats_ca" {
-  model = juju_model.controller.name
+  model_uuid = juju_model.controller.uuid
 
   application {
     name     = juju_application.ca.name
@@ -166,7 +166,7 @@ resource "juju_integration" "nats_ca" {
 }
 
 resource "juju_integration" "gateway_ca" {
-  model = juju_model.controller.name
+  model_uuid = juju_model.controller.uuid
 
   application {
     name     = juju_application.ca.name
@@ -180,7 +180,7 @@ resource "juju_integration" "gateway_ca" {
 }
 
 resource "juju_integration" "dashboard_ca" {
-  model = juju_model.controller.name
+  model_uuid = juju_model.controller.uuid
 
   application {
     name     = juju_application.ca.name
@@ -194,16 +194,16 @@ resource "juju_integration" "dashboard_ca" {
 }
 
 resource "juju_offer" "nats_offer" {
-  model            = juju_model.controller.name
+  model_uuid       = juju_model.controller.uuid
   application_name = juju_application.nats.name
-  endpoint         = "client"
+  endpoints        = ["client"]
 }
 
 resource "juju_application" "cos_agent" {
   count = var.enable_cos ? 1 : 0
   name  = "grafana-agent"
 
-  model = juju_model.controller.name
+  model_uuid = juju_model.controller.uuid
 
   charm {
     name = "grafana-agent"
@@ -219,8 +219,8 @@ resource "juju_application" "cos_agent" {
 }
 
 resource "juju_integration" "gateway_cos" {
-  count = var.enable_cos ? 1 : 0
-  model = juju_model.controller.name
+  count      = var.enable_cos ? 1 : 0
+  model_uuid = juju_model.controller.uuid
 
   application {
     name     = juju_application.gateway.name
@@ -235,7 +235,7 @@ resource "juju_integration" "gateway_cos" {
 
 
 resource "juju_machine" "controller_node" {
-  model       = juju_model.controller.name
+  model_uuid  = juju_model.controller.uuid
   count       = local.num_units
   base        = local.base
   name        = "anbox-controller-${count.index}"

--- a/modules/controller/outputs.tf
+++ b/modules/controller/outputs.tf
@@ -12,6 +12,11 @@ output "model_name" {
   description = "Model name for the deployed controller."
 }
 
+output "model_uuid" {
+  value       = juju_model.controller.uuid
+  description = "Model uuid for the deployed controller."
+}
+
 output "dashboard_app_name" {
   value       = juju_application.dashboard.name
   description = "Anbox Cloud Dashboard application name deployed in the controller model."

--- a/modules/controller/provider.tf
+++ b/modules/controller/provider.tf
@@ -5,7 +5,7 @@
 terraform {
   required_providers {
     juju = {
-      version = "~> 0.19.0"
+      version = "~> 1.3.0"
       source  = "juju/juju"
     }
   }

--- a/modules/registry/README.md
+++ b/modules/registry/README.md
@@ -16,7 +16,7 @@ includes:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.6 |
-| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 0.19.0 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.3.0 |
 
 ## Providers
 
@@ -46,6 +46,7 @@ No modules.
 | <a name="input_constraints"></a> [constraints](#input\_constraints) | List of constraints that need to be applied to applications. Each constraint must be of format `<constraint_name>=<constraint_value>` | `list(string)` | `[]` | no |
 | <a name="input_enable_ha"></a> [enable\_ha](#input\_enable\_ha) | Number of lxd nodes to deploy per subcluster | `bool` | `false` | no |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | SSH key to be imported in the juju models. No key is imported by default. | `string` | `""` | no |
+| <a name="input_ubuntu_pro_token"></a> [ubuntu\_pro\_token](#input\_ubuntu\_pro\_token) | Ubuntu Advantage token that is received with your license of Anbox Cloud. | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/registry/main.tf
+++ b/modules/registry/main.tf
@@ -19,15 +19,15 @@ resource "juju_model" "registry" {
 }
 
 resource "juju_ssh_key" "this" {
-  count   = length(var.ssh_public_key) > 0 ? 1 : 0
-  model   = juju_model.registry.name
-  payload = trim(var.ssh_public_key, "\n")
+  count      = length(var.ssh_public_key) > 0 ? 1 : 0
+  model_uuid = juju_model.registry.uuid
+  payload    = trim(var.ssh_public_key, "\n")
 }
 
 resource "juju_application" "aar" {
   name = "aar"
 
-  model       = juju_model.registry.name
+  model_uuid  = juju_model.registry.uuid
   constraints = join(" ", var.constraints)
 
   charm {
@@ -52,15 +52,15 @@ resource "juju_application" "aar" {
 }
 
 resource "juju_offer" "client_offer" {
-  model            = juju_model.registry.name
+  model_uuid       = juju_model.registry.uuid
   application_name = juju_application.aar.name
-  endpoint         = "client"
+  endpoints        = ["client"]
   name             = "aar-client"
 }
 
 resource "juju_offer" "publisher_offer" {
-  model            = juju_model.registry.name
+  model_uuid       = juju_model.registry.uuid
   application_name = juju_application.aar.name
   name             = "aar-publisher"
-  endpoint         = "publisher"
+  endpoints        = ["publisher"]
 }

--- a/modules/registry/provider.tf
+++ b/modules/registry/provider.tf
@@ -5,7 +5,7 @@
 terraform {
   required_providers {
     juju = {
-      version = "~> 0.19.0"
+      version = "~> 1.3.0"
       source  = "juju/juju"
     }
   }

--- a/modules/subcluster/README.md
+++ b/modules/subcluster/README.md
@@ -26,7 +26,7 @@ setup network rules properly on the lxd node.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.6 |
-| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 0.19.0 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.3.0 |
 
 ## Providers
 
@@ -79,6 +79,7 @@ No modules.
 | <a name="input_model_suffix"></a> [model\_suffix](#input\_model\_suffix) | Suffix to attach for model | `string` | n/a | yes |
 | <a name="input_registry_config"></a> [registry\_config](#input\_registry\_config) | Object to represent connection details for connecting to anbox registry | <pre>object({<br/>    mode      = string<br/>    offer_url = string<br/>  })</pre> | `null` | no |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | SSH key to be imported in the juju models. No key is imported by default. | `string` | `""` | no |
+| <a name="input_ubuntu_pro_token"></a> [ubuntu\_pro\_token](#input\_ubuntu\_pro\_token) | Ubuntu Advantage token that is received with your license of Anbox Cloud. | `string` | `""` | no |
 
 ## Outputs
 
@@ -87,4 +88,5 @@ No modules.
 | <a name="output_agent_app_name"></a> [agent\_app\_name](#output\_agent\_app\_name) | Anbox Stream Agent application name deployed in the subcluster model. |
 | <a name="output_ams_offer_url"></a> [ams\_offer\_url](#output\_ams\_offer\_url) | Juju offer url for connecting to the AMS charm. |
 | <a name="output_model_name"></a> [model\_name](#output\_model\_name) | Model name for the deployed subcluster. |
+| <a name="output_model_uuid"></a> [model\_uuid](#output\_model\_uuid) | Model uuid for the deployed subcluster. |
 <!-- END_TF_DOCS -->

--- a/modules/subcluster/control_plane.tf
+++ b/modules/subcluster/control_plane.tf
@@ -21,15 +21,15 @@ resource "juju_model" "subcluster" {
 }
 
 resource "juju_ssh_key" "this" {
-  count   = length(var.ssh_public_key) > 0 ? 1 : 0
-  model   = juju_model.subcluster.name
-  payload = trim(var.ssh_public_key, "\n")
+  count      = length(var.ssh_public_key) > 0 ? 1 : 0
+  model_uuid = juju_model.subcluster.uuid
+  payload    = trim(var.ssh_public_key, "\n")
 }
 
 resource "juju_application" "ams" {
   name = "ams"
 
-  model       = juju_model.subcluster.name
+  model_uuid  = juju_model.subcluster.uuid
   constraints = join(" ", var.constraints)
   machines    = juju_machine.ams_node[*].machine_id
 
@@ -56,7 +56,7 @@ resource "juju_application" "etcd" {
   count = var.external_etcd ? 1 : 0
   name  = "etcd"
 
-  model       = juju_model.subcluster.name
+  model_uuid  = juju_model.subcluster.uuid
   constraints = join(" ", var.constraints)
 
   charm {
@@ -81,7 +81,7 @@ resource "juju_application" "etcd" {
 resource "juju_application" "ca" {
   name = "ca"
 
-  model       = juju_model.subcluster.name
+  model_uuid  = juju_model.subcluster.uuid
   constraints = join(" ", var.constraints)
 
   charm {
@@ -97,7 +97,7 @@ resource "juju_application" "etcd_ca" {
   count = var.external_etcd ? 1 : 0
   name  = "etcd-ca"
 
-  model       = juju_model.subcluster.name
+  model_uuid  = juju_model.subcluster.uuid
   constraints = join(" ", var.constraints)
 
   charm {
@@ -110,8 +110,8 @@ resource "juju_application" "etcd_ca" {
 }
 
 resource "juju_integration" "ams_db" {
-  count = var.external_etcd ? 1 : 0
-  model = juju_model.subcluster.name
+  count      = var.external_etcd ? 1 : 0
+  model_uuid = juju_model.subcluster.uuid
 
   application {
     name     = juju_application.ams.name
@@ -125,8 +125,8 @@ resource "juju_integration" "ams_db" {
 }
 
 resource "juju_integration" "etcd_ca" {
-  count = var.external_etcd ? 1 : 0
-  model = juju_model.subcluster.name
+  count      = var.external_etcd ? 1 : 0
+  model_uuid = juju_model.subcluster.uuid
 
   application {
     name     = one(juju_application.etcd_ca[*].name)
@@ -142,7 +142,7 @@ resource "juju_integration" "etcd_ca" {
 resource "juju_application" "agent" {
   name = "anbox-stream-agent"
 
-  model       = juju_model.subcluster.name
+  model_uuid  = juju_model.subcluster.uuid
   constraints = join(" ", var.constraints)
 
   charm {
@@ -170,7 +170,7 @@ resource "juju_application" "agent" {
 resource "juju_application" "coturn" {
   name = "coturn"
 
-  model       = juju_model.subcluster.name
+  model_uuid  = juju_model.subcluster.uuid
   constraints = join(" ", var.constraints)
 
   charm {
@@ -192,7 +192,7 @@ resource "juju_application" "coturn" {
 }
 
 resource "juju_integration" "agent_ams" {
-  model = juju_model.subcluster.name
+  model_uuid = juju_model.subcluster.uuid
 
   application {
     name     = juju_application.agent.name
@@ -206,7 +206,7 @@ resource "juju_integration" "agent_ams" {
 }
 
 resource "juju_integration" "ams_agent_streaming" {
-  model = juju_model.subcluster.name
+  model_uuid = juju_model.subcluster.uuid
 
   application {
     name     = juju_application.agent.name
@@ -221,7 +221,7 @@ resource "juju_integration" "ams_agent_streaming" {
 
 
 resource "juju_integration" "agent_ca" {
-  model = juju_model.subcluster.name
+  model_uuid = juju_model.subcluster.uuid
 
   application {
     name     = juju_application.ca.name
@@ -235,7 +235,7 @@ resource "juju_integration" "agent_ca" {
 }
 
 resource "juju_integration" "coturn_agent" {
-  model = juju_model.subcluster.name
+  model_uuid = juju_model.subcluster.uuid
 
   application {
     name     = juju_application.coturn.name
@@ -249,8 +249,8 @@ resource "juju_integration" "coturn_agent" {
 }
 
 resource "juju_integration" "ams_aar" {
-  count = var.registry_config != null ? 1 : 0
-  model = juju_model.subcluster.name
+  count      = var.registry_config != null ? 1 : 0
+  model_uuid = juju_model.subcluster.uuid
 
   application {
     name     = juju_application.ams.name
@@ -263,9 +263,9 @@ resource "juju_integration" "ams_aar" {
 }
 
 resource "juju_offer" "ams_offer" {
-  model            = juju_model.subcluster.name
+  model_uuid       = juju_model.subcluster.uuid
   application_name = juju_application.ams.name
-  endpoint         = "rest-api"
+  endpoints        = ["rest-api"]
   name             = "ams${local.offer_suffix}"
 }
 
@@ -274,7 +274,7 @@ resource "juju_application" "cos_agent" {
   count = var.enable_cos ? 1 : 0
   name  = "grafana-agent"
 
-  model = juju_model.subcluster.name
+  model_uuid = juju_model.subcluster.uuid
 
   charm {
     name = "grafana-agent"
@@ -290,8 +290,8 @@ resource "juju_application" "cos_agent" {
 }
 
 resource "juju_integration" "ams_cos" {
-  count = var.enable_cos ? 1 : 0
-  model = juju_model.subcluster.name
+  count      = var.enable_cos ? 1 : 0
+  model_uuid = juju_model.subcluster.uuid
 
   application {
     name     = juju_application.ams.name
@@ -305,7 +305,7 @@ resource "juju_integration" "ams_cos" {
 }
 
 resource "juju_machine" "ams_node" {
-  model       = juju_model.subcluster.name
+  model_uuid  = juju_model.subcluster.uuid
   count       = local.num_units
   base        = local.base
   name        = "ams-${count.index}"
@@ -314,7 +314,7 @@ resource "juju_machine" "ams_node" {
 
 resource "juju_machine" "db_node" {
   count       = var.external_etcd ? local.num_units : 0
-  model       = juju_model.subcluster.name
+  model_uuid  = juju_model.subcluster.uuid
   base        = local.base
   name        = "db-${count.index}"
   constraints = join(" ", var.constraints)

--- a/modules/subcluster/data_plane.tf
+++ b/modules/subcluster/data_plane.tf
@@ -5,7 +5,7 @@
 resource "juju_application" "lxd" {
   name = "lxd"
 
-  model       = juju_model.subcluster.name
+  model_uuid  = juju_model.subcluster.uuid
   constraints = join(" ", concat(var.constraints, ["root-disk=10240M"]))
 
   charm {
@@ -28,7 +28,7 @@ resource "juju_application" "lxd" {
 }
 
 resource "juju_integration" "ams_lxd" {
-  model = juju_model.subcluster.name
+  model_uuid = juju_model.subcluster.uuid
 
   application {
     name     = juju_application.ams.name
@@ -42,7 +42,7 @@ resource "juju_integration" "ams_lxd" {
 }
 
 resource "juju_machine" "lxd_node" {
-  model       = juju_model.subcluster.name
+  model_uuid  = juju_model.subcluster.uuid
   count       = var.lxd_nodes
   base        = local.base
   name        = "lxd-${count.index}"

--- a/modules/subcluster/output.tf
+++ b/modules/subcluster/output.tf
@@ -12,6 +12,11 @@ output "model_name" {
   description = "Model name for the deployed subcluster."
 }
 
+output "model_uuid" {
+  value       = juju_model.subcluster.uuid
+  description = "Model uuid for the deployed subcluster."
+}
+
 output "agent_app_name" {
   value       = juju_application.agent.name
   description = "Anbox Stream Agent application name deployed in the subcluster model."

--- a/modules/subcluster/provider.tf
+++ b/modules/subcluster/provider.tf
@@ -5,7 +5,7 @@
 terraform {
   required_providers {
     juju = {
-      version = "~> 0.19.0"
+      version = "~> 1.3.0"
       source  = "juju/juju"
     }
   }

--- a/provider.tf
+++ b/provider.tf
@@ -5,7 +5,7 @@
 terraform {
   required_providers {
     juju = {
-      version = "~> 0.19.0"
+      version = "~> 1.3.0"
       source  = "juju/juju"
     }
   }


### PR DESCRIPTION
## Done

* Bump the terraform provider to 1.3.0
* Fix the breaking changes due to the update

## QA

* CI passes 

## JIRA / Launchpad bug

Fixes [AC-4052](https://warthogs.atlassian.net/browse/AC-4052)

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
The documentation is generated and updated along with the change

[AC-4052]: https://warthogs.atlassian.net/browse/AC-4052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ