### PR TITLE
fix: add channel for node controller snap within the lxd charm

### DIFF
--- a/modules/subcluster/data_plane.tf
+++ b/modules/subcluster/data_plane.tf
@@ -15,7 +15,8 @@ resource "juju_application" "lxd" {
   }
 
   config = {
-    ua_token = var.ubuntu_pro_token
+    ua_token                        = var.ubuntu_pro_token
+    node_controller_snap_risk_level = local.risk
   }
 
   machines = juju_machine.lxd_node[*].machine_id


### PR DESCRIPTION


## Done

* As of 1.28 release of anbox cloud we have started bundling the ams-node-controller snap within the LXD snap so the ams-lxd charm needs to specify the new config option.

## QA

* CI passes

