### PR TITLE
Add 7 days cooldown for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,9 @@
     "helpers:pinGitHubActionDigests",
     "regexManagers:dockerfileVersions"
   ],
+  "minimumreleaseage": "7 days",
+  "minimumreleaseagebehaviour": "timestamp-optional",
+  "prcreation": "not-pending",
   "automergeType": "branch",
   "packageRules": [
     {


### PR DESCRIPTION
## Done

Add 7 days cooldown for Renovate updates.

See https://docs.renovatebot.com/key-concepts/minimum-release-age/

## QA

Check config, and let Renovate run.

## JIRA / Launchpad bug

Contributes to [AC-4433](https://warthogs.atlassian.net/browse/AC-4433)

## Documentation

N/A

[AC-4433]: https://warthogs.atlassian.net/browse/AC-4433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ