### PR TITLE
Disable trivy security scan for the time being

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -13,11 +13,15 @@ jobs:
   build:
     name: Run triviy security scan
     runs-on: ubuntu-latest
+    env:
+      TRIVY_ENABLED: ${{ vars.TRIVY_ENABLED || 'false' }} # TODO: re-enable after the upstream Trivy supply-chain incident is resolved and audited
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup Trivy
+      if: env.TRIVY_ENABLED == 'true'
       uses: ./.github/actions/setup-trivy
     - name: Run Trivy vulnerability scanner
+      if: env.TRIVY_ENABLED == 'true'
       run: |
         trivy repository "$GITHUB_WORKSPACE" \
           -c trivy.yaml \
@@ -26,13 +30,16 @@ jobs:
           --cache-dir="$GITHUB_WORKSPACE"/.cache/trivy
 
     - name: Setup Terraform
+      if: env.TRIVY_ENABLED == 'true'
       run:
         sudo snap install terraform --channel latest/stable --classic
     - name: Setup operator environment
+      if: env.TRIVY_ENABLED == 'true'
       uses: charmed-kubernetes/actions-operator@1c7c9a30d7d233e26e7a4fc1505cc44bbd937229
       with:
         provider: lxd
     - name: Create terraform Plan
+      if: env.TRIVY_ENABLED == 'true'
       run: |
         cat <<EOF > default.auto.tfvars
         anbox_channel  = "1.27/stable"
@@ -49,7 +56,9 @@ jobs:
         EOF
         terraform init && terraform plan -out tfplan -var-file=default.auto.tfvars
     - name: Run Trivy Terraform Plan Scanner
+      if: env.TRIVY_ENABLED == 'true'
       run: |
         trivy config tfplan
     - name: Compare Trivy results with KEV list
+      if: env.TRIVY_ENABLED == 'true'
       run: bash ./scripts/compare_kev_vulnerabilities.sh

--- a/.github/workflows/trivy-update.yaml
+++ b/.github/workflows/trivy-update.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   trivy-update:
+    if: vars.TRIVY_ENABLED == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Done

Disable trivy scans due to the recent security incident involving
malicious releases in the upstream repository. Reference:
    
       https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release
    
This is a temporary measure to mitigate supply chain risks while we
evaluate the situation. An environment variable is used to bypass
the check, as the scan remains a mandatory requirement for PR merges.

## QA

N/A

## JIRA / Launchpad bug

Contributes to [AC-4441](https://warthogs.atlassian.net/browse/AC-4441)

[AC-4441]: https://warthogs.atlassian.net/browse/AC-4441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ