### PR TITLE
fix: add a variable to detect aws support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ module "subcluster" {
   enable_cos       = var.enable_cos
   ssh_public_key   = length(var.ssh_key_path) > 0 ? file(var.ssh_key_path) : ""
   ubuntu_pro_token = var.ubuntu_pro_token
+  cloud_type       = var.cloud_type
 
   // We let the `lxd_node_count` value override the HA configuration for number
   // of LXD nodes.

--- a/modules/subcluster/control_plane.tf
+++ b/modules/subcluster/control_plane.tf
@@ -7,6 +7,7 @@ locals {
   // an identifier for an offer.
   offer_suffix = replace(var.model_suffix, "/[-_.]*/", "")
   num_units    = var.enable_ha ? 3 : 1
+  is_aws       = var.cloud_type == "aws"
 }
 
 resource "juju_model" "subcluster" {

--- a/modules/subcluster/data_plane.tf
+++ b/modules/subcluster/data_plane.tf
@@ -5,8 +5,9 @@
 resource "juju_application" "lxd" {
   name = "lxd"
 
-  model_uuid  = juju_model.subcluster.uuid
-  constraints = join(" ", concat(var.constraints, ["root-disk=10240M"]))
+  model_uuid         = juju_model.subcluster.uuid
+  constraints        = join(" ", concat(var.constraints, ["root-disk=10240M"]))
+  storage_directives = local.is_aws ? { "pool" = "ebs-ssd,100G,1" } : null
 
   charm {
     name    = "ams-lxd"

--- a/modules/subcluster/variables.tf
+++ b/modules/subcluster/variables.tf
@@ -64,3 +64,14 @@ variable "ubuntu_pro_token" {
   default     = ""
 }
 
+variable "cloud_type" {
+  description = "The cloud type where the Juju model is deployed. Controls cloud-specific resource configuration."
+  type        = string
+  default     = "lxd"
+
+  validation {
+    condition     = contains(["lxd", "aws"], var.cloud_type)
+    error_message = "cloud_type must be one of: lxd, aws."
+  }
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -68,3 +68,14 @@ variable "ssh_key_path" {
   default     = ""
 }
 
+variable "cloud_type" {
+  description = "The cloud type where the Juju models are deployed. Controls cloud-specific resource configuration."
+  type        = string
+  default     = "lxd"
+
+  validation {
+    condition     = contains(["lxd", "aws"], var.cloud_type)
+    error_message = "cloud_type must be one of: lxd, aws."
+  }
+}
+


### PR DESCRIPTION

## Done

This commit adds a new variable called `cloud_type` since there's not internal way from the resources to detect the underlying cloud. This is needed becuase the lxd charm fails to deploy on aws without proper ebs storage volume support.
